### PR TITLE
feat: Add random task button and functionality

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,1 +1,6 @@
-{}
+{
+    "randomTaskMenuButton": "Random Task",
+    "randomTaskDialogTitle": "Randomly Selected Task",
+    "noTasksAvailableDialogTitle": "No Tasks",
+    "noTasksAvailableDialogMessage": "There are no tasks available to pick from."
+}

--- a/lib/mixin/app_locale.dart
+++ b/lib/mixin/app_locale.dart
@@ -82,6 +82,10 @@ mixin AppLocale {
     doUwant2Delete: "Do you want to delete?",
     thisCantBeUndone: "This can't be undone",
     selectLanguage: "Select Language",
+    AppLocale.randomTaskMenuButton: "Random Task",
+    AppLocale.randomTaskDialogTitle: "Randomly Selected Task",
+    AppLocale.noTasksAvailableDialogTitle: "No Tasks",
+    AppLocale.noTasksAvailableDialogMessage: "There are no tasks available to pick from.",
   };
   static const Map<String, dynamic> HE = {
     title: 'המשימות שלי',
@@ -122,5 +126,9 @@ mixin AppLocale {
     doUwant2Delete: "האם למחוק?",
     thisCantBeUndone: "פעולה זו בלתי הפיכה",
     selectLanguage: "בחר שפה",
+    AppLocale.randomTaskMenuButton: "משימה אקראית",
+    AppLocale.randomTaskDialogTitle: "משימה שנבחרה בצורה אקראית",
+    AppLocale.noTasksAvailableDialogTitle: "אין משימות",
+    AppLocale.noTasksAvailableDialogMessage: "אין כרגע משימות שעלייך לבצע",
   };
 }

--- a/lib/mixin/app_locale.dart
+++ b/lib/mixin/app_locale.dart
@@ -38,6 +38,11 @@ mixin AppLocale {
   static const String thisCantBeUndone = "thisCantBeUndone";
   static const String selectLanguage = "selectLanguage";
 
+  static const String randomTaskMenuButton = 'randomTaskMenuButton';
+  static const String randomTaskDialogTitle = 'randomTaskDialogTitle';
+  static const String noTasksAvailableDialogTitle = 'noTasksAvailableDialogTitle';
+  static const String noTasksAvailableDialogMessage = 'noTasksAvailableDialogMessage';
+
   static const Map<String, dynamic> EN = {
     title: 'Todo List',
     lang: 'Language',

--- a/lib/screens/homepage.dart
+++ b/lib/screens/homepage.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -21,6 +22,8 @@ import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'dart:html' as html;
 
 import 'onboarding.dart';
+
+const String kRandomTaskMenuButtonName = 'randomTask';
 
 class HomePage extends StatefulWidget {
   const HomePage({
@@ -164,6 +167,8 @@ class _HomePageState extends State<HomePage> with PWAInstallerMixin {
                           context,
                           MaterialPageRoute(
                               builder: (context) => const SettingsScreen()));
+                    } else if (value == kRandomTaskMenuButtonName) {
+                      _showRandomTask();
                     }
                   },
                   itemBuilder: (BuildContext context) {
@@ -245,6 +250,20 @@ class _HomePageState extends State<HomePage> with PWAInstallerMixin {
                           ),
                           const SizedBox(width: 8.0),
                           Text(AppLocale.settings.getString(context)),
+                        ],
+                      ),
+                    ));
+                    // Add Random Task button
+                    popupMenuItems.add(PopupMenuItem<String>(
+                      value: kRandomTaskMenuButtonName,
+                      child: Row(
+                        children: [
+                          const Icon(
+                            Icons.shuffle,
+                            color: Colors.blue,
+                          ),
+                          const SizedBox(width: 8.0),
+                          Text(AppLocale.randomTaskMenuButton.getString(context)),
                         ],
                       ),
                     ));
@@ -715,5 +734,35 @@ class _HomePageState extends State<HomePage> with PWAInstallerMixin {
       // Cancel
       Navigator.of(context).pop(); // dismiss dialog
     });
+  }
+
+  void _showRandomTask() {
+    final availableTasks = items
+        .where((item) => !item.isArchived && !item.isChecked)
+        .toList();
+
+    if (availableTasks.isEmpty) {
+      DialogHelper.showAlertDialog(
+        context,
+        AppLocale.noTasksAvailableDialogTitle.getString(context),
+        AppLocale.noTasksAvailableDialogMessage.getString(context),
+        () {
+          Navigator.of(context).pop(); // dismiss dialog
+        },
+        null,
+      );
+    } else {
+      final randomIndex = Random().nextInt(availableTasks.length);
+      final randomTask = availableTasks[randomIndex];
+      DialogHelper.showAlertDialog(
+        context,
+        AppLocale.randomTaskDialogTitle.getString(context),
+        randomTask.text,
+        () {
+          Navigator.of(context).pop(); // dismiss dialog
+        },
+        null,
+      );
+    }
   }
 }


### PR DESCRIPTION
Adds a 'Random Task' button to the AppBar menu.
When clicked, this button triggers a dialog that displays a randomly selected, non-archived, and non-completed task. If no such tasks are available, a message is shown to you.

New localized strings for the button text and dialog messages have been added to `intl_en.arb`.

Note: The `flutter gen-l10n` command needs to be run manually to update the generated Dart localization files.