### PR TITLE
feat: Prompt PWA installation on homepage load

### DIFF
--- a/lib/screens/homepage.dart
+++ b/lib/screens/homepage.dart
@@ -137,6 +137,10 @@ class _HomePageState extends State<HomePage> with PWAInstallerMixin {
     _loadingData = loadList();
     if (false) initAds();
     initializeInstallPrompt();
+    // Automatically show the install prompt if available
+    if (isInstallable()) {
+      showInstallPrompt();
+    }
     super.initState();
   }
 


### PR DESCRIPTION
Automatically shows the PWA installation prompt to you when you land on the homepage after logging in or signing up, provided the app is installable and not already installed on your device.

The prompt is triggered from the `initState` method in `lib/screens/homepage.dart`. The existing `PWAInstallerMixin` is leveraged, and its `isInstallableRightNow` flag ensures the prompt is shown only once per session or until the app is installed. The manual installation option in the menu remains functional.