### PR TITLE
Fix Firebase path concatenation in getData

### DIFF
--- a/lib/repo/firebase_realtime_database_repository.dart
+++ b/lib/repo/firebase_realtime_database_repository.dart
@@ -27,7 +27,7 @@ class FirebaseRealtimeDatabaseRepository {
   }
 
   Future<Map<String, dynamic>> getData(String path, String referencePath) async {
-    final reference = FirebaseDatabase.instance.ref(referencePath).ref.child(path);
+    final reference = FirebaseDatabase.instance.ref('$referencePath/$path');
     final event = await reference.once();
     if (event.snapshot.value is Map) {
       final data = event.snapshot.value as Map;


### PR DESCRIPTION
## Summary
- ensure `getData` concatenates `referencePath` and `path` properly

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558bf73cc4832ea86dbf65be583698